### PR TITLE
feat: Add symlinks configuration support for external barrel files

### DIFF
--- a/.changeset/few-ends-look.md
+++ b/.changeset/few-ends-look.md
@@ -1,0 +1,29 @@
+---
+"swc-plugin-barrel-files": minor
+---
+
+Add symlinks configuration support for external barrel files
+
+This feature introduces a new `symlinks` configuration option that enables the plugin to work with external files and directories outside the current working directory. This is particularly useful in monorepo setups or when working with external libraries that need barrel file optimization.
+
+This feature overcomes SWC plugin limitations that restrict file access to the current working directory, enabling barrel file optimization for shared workspace modules.
+
+**Configuration Example:**
+
+```json
+{
+    "symlinks": {
+        "../external-lib/index.ts": "./node_modules/external-lib/index.ts",
+        "../shared-workspace": "./symlinks/workspace/src"
+    }
+}
+```
+
+**How it Works:**
+
+When the plugin encounters an import from an external path, it:
+
+1. Checks if the path matches any symlink mapping
+2. Resolves it to the internal symlinked path
+3. Processes the barrel file using the internal path
+4. Generates optimized direct imports

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ node_modules
 .swc
 target
 tests/fixtures
+perf/fixtures
+perf/output
+perf/.swcrc
 swc_plugin_barrel_files.wasm
 mise.toml
 todo.md

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "postbuild": "cp target/wasm32-wasip1/release/swc_plugin_barrel_files.wasm .",
         "test": "vitest run",
         "test:watch": "vitest",
+        "perf": "tsx perf/run.ts",
+        "generate-perf-fixtures": "tsx perf/generate-fixtures.ts",
         "changeset": "changeset",
         "ci:version": "changeset version",
         "ci:release": "pnpm build && changeset publish"
@@ -34,9 +36,12 @@
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.1",
         "@changesets/cli": "^2.29.5",
+        "@swc/cli": "0.7.8",
         "@swc/core": "1.12.11",
+        "@swc/plugin-noop": "9.0.0",
         "@types/node": "22.13.11",
         "prettier": "3.6.2",
+        "tsx": "4.20.3",
         "typescript": "5.8.3",
         "vitest": "3.2.4"
     },

--- a/perf/generate-fixtures.ts
+++ b/perf/generate-fixtures.ts
@@ -1,0 +1,326 @@
+import * as fs from "fs";
+import * as path from "path";
+
+// --- Constants ---
+const TOTAL_COMPONENTS = 10000;
+const COMPONENTS_PER_MODULE = 15;
+const TOTAL_MODULES = Math.ceil(TOTAL_COMPONENTS / COMPONENTS_PER_MODULE);
+const FIXTURES_DIR = path.resolve(__dirname, "./fixtures");
+
+// Common NPM packages to import from
+const NPM_PACKAGES = [
+    "react",
+    "react-dom",
+    "lodash",
+    "classnames",
+    "axios",
+    "date-fns",
+    "framer-motion",
+    "react-query",
+    "styled-components",
+    "react-router-dom",
+    "uuid",
+    "moment",
+    "ramda",
+    "immutable",
+    "rxjs",
+];
+
+// --- Utility Functions ---
+
+/**
+ * Shuffles an array and returns a new shuffled array
+ */
+function shuffle<T>(array: T[]): T[] {
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+}
+
+/**
+ * Gets a random selection of items from an array
+ */
+function getRandomItems<T>(array: T[], count: number): T[] {
+    return shuffle(array).slice(0, count);
+}
+
+/**
+ * Generates a component name based on module and component index
+ */
+function getComponentName(moduleIndex: number, componentIndex: number): string {
+    const globalIndex = moduleIndex * COMPONENTS_PER_MODULE + componentIndex;
+    return `Component${globalIndex.toString().padStart(5, "0")}`;
+}
+
+/**
+ * Gets the module directory name
+ */
+function getModuleName(moduleIndex: number): string {
+    return `module-${moduleIndex.toString().padStart(3, "0")}`;
+}
+
+/**
+ * Generates imports for a component
+ */
+function generateImports(
+    moduleIndex: number,
+    componentIndex: number,
+): {
+    imports: string[];
+    usedComponents: string[];
+} {
+    const imports: string[] = [];
+    const usedComponents: string[] = [];
+
+    // 1. Same-module imports (5 components from current module)
+    const currentModuleComponents: string[] = [];
+    for (let i = 0; i < COMPONENTS_PER_MODULE; i++) {
+        if (i !== componentIndex) {
+            currentModuleComponents.push(getComponentName(moduleIndex, i));
+        }
+    }
+    const sameModuleImports = getRandomItems(currentModuleComponents, Math.min(5, currentModuleComponents.length));
+
+    sameModuleImports.forEach((componentName) => {
+        imports.push(`import { ${componentName} } from './${componentName}';`);
+        usedComponents.push(componentName);
+    });
+
+    // 2. Cross-module barrel file imports (5 components from different modules)
+    const otherModules = Array.from({ length: TOTAL_MODULES }, (_, i) => i).filter((i) => i !== moduleIndex);
+    const selectedModules = getRandomItems(otherModules, Math.min(5, otherModules.length));
+
+    selectedModules.forEach((targetModuleIndex) => {
+        const targetComponentIndex = Math.floor(Math.random() * COMPONENTS_PER_MODULE);
+        const componentName = getComponentName(targetModuleIndex, targetComponentIndex);
+        const moduleName = getModuleName(targetModuleIndex);
+        imports.push(`import { ${componentName} } from '../${moduleName}/index.ts';`);
+        usedComponents.push(componentName);
+    });
+
+    // 3. Cross-module alias imports using #src/* (5 components from different modules)
+    const aliasModules = getRandomItems(
+        otherModules.filter((i) => !selectedModules.includes(i)),
+        Math.min(5, otherModules.length - selectedModules.length),
+    );
+
+    aliasModules.forEach((targetModuleIndex) => {
+        const targetComponentIndex = Math.floor(Math.random() * COMPONENTS_PER_MODULE);
+        const componentName = getComponentName(targetModuleIndex, targetComponentIndex);
+        const moduleName = getModuleName(targetModuleIndex);
+        imports.push(`import { ${componentName} } from '#src/${moduleName}';`);
+        usedComponents.push(componentName);
+    });
+
+    // 4. NPM package imports (5 random packages)
+    const selectedPackages = getRandomItems(NPM_PACKAGES, 5);
+    selectedPackages.forEach((packageName, index) => {
+        // Generate different import patterns for variety
+        switch (index % 4) {
+            case 0:
+                imports.push(`import ${packageName.replace(/[^a-zA-Z]/g, "")} from '${packageName}';`);
+                break;
+            case 1:
+                imports.push(`import { ${packageName.replace(/[^a-zA-Z]/g, "")}Util } from '${packageName}';`);
+                break;
+            case 2:
+                imports.push(`import * as ${packageName.replace(/[^a-zA-Z]/g, "")}Lib from '${packageName}';`);
+                break;
+            case 3:
+                imports.push(
+                    `import { default as ${packageName.replace(/[^a-zA-Z]/g, "")}Default } from '${packageName}';`,
+                );
+                break;
+        }
+    });
+
+    return { imports, usedComponents };
+}
+
+/**
+ * Generates the content of a React component
+ */
+function generateComponentContent(moduleIndex: number, componentIndex: number): string {
+    const componentName = getComponentName(moduleIndex, componentIndex);
+    const { imports, usedComponents } = generateImports(moduleIndex, componentIndex);
+
+    // Generate some dummy props and state
+    const props = ["title", "description", "isVisible", "onClick", "className"];
+    const stateVars = ["isLoading", "data", "error", "count"];
+
+    return `${imports.join("\n")}
+
+interface ${componentName}Props {
+  ${props.map((prop) => `${prop}?: any;`).join("\n  ")}
+}
+
+export const ${componentName}: React.FC<${componentName}Props> = ({
+  ${props.join(",\n  ")}
+}) => {
+  // State management
+  const [${stateVars.join(", ")}] = React.useState({
+    ${stateVars.map((v) => `${v}: null`).join(",\n    ")}
+  });
+
+  // Effect hooks for demonstration
+  React.useEffect(() => {
+    // Simulate data fetching
+    const fetchData = async () => {
+      try {
+        // Simulate API call
+        await new Promise(resolve => setTimeout(resolve, 100));
+        console.log('Data loaded for ${componentName}');
+      } catch (err) {
+        console.error('Error in ${componentName}:', err);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  // Event handlers
+  const handleClick = React.useCallback(() => {
+    if (onClick) {
+      onClick();
+    }
+    console.log('${componentName} clicked');
+  }, [onClick]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log('Form submitted in ${componentName}');
+  };
+
+  // Render logic with used components
+  const renderContent = () => {
+    if (isLoading) {
+      return <div>Loading...</div>;
+    }
+
+    return (
+      <div className={\`${componentName.toLowerCase()}-container \${className || ''}\`}>
+        <h2>{title || '${componentName} Title'}</h2>
+        <p>{description || 'Default description for ${componentName}'}</p>
+
+        {/* Using imported components */}
+        <div className="imported-components">
+          ${usedComponents
+              .slice(0, 10)
+              .map((comp) => `<${comp} key="${comp}" />`)
+              .join("\n          ")}
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            placeholder="Enter text for ${componentName}"
+            onChange={(e) => console.log(e.target.value)}
+          />
+          <button type="submit">Submit</button>
+        </form>
+
+        <div className="actions">
+          <button onClick={handleClick} disabled={!isVisible}>
+            Click me in ${componentName}
+          </button>
+        </div>
+
+        {/* Additional content to reach ~100 lines */}
+        <div className="additional-content">
+          <ul>
+            {Array.from({ length: 5 }, (_, i) => (
+              <li key={i}>Item {i + 1} in ${componentName}</li>
+            ))}
+          </ul>
+
+          <div className="metrics">
+            <span>Count: {count}</span>
+            <span>Error: {error ? 'Yes' : 'No'}</span>
+            <span>Data: {data ? 'Loaded' : 'Not loaded'}</span>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="${componentName.toLowerCase()}-wrapper">
+      {renderContent()}
+    </div>
+  );
+};
+
+export default ${componentName};
+`;
+}
+
+/**
+ * Generates the barrel file (index.ts) content for a module
+ */
+function generateBarrelFileContent(moduleIndex: number): string {
+    const exports: string[] = [];
+
+    for (let i = 0; i < COMPONENTS_PER_MODULE; i++) {
+        const componentName = getComponentName(moduleIndex, i);
+        exports.push(`export { ${componentName} } from './${componentName}';`);
+    }
+
+    return exports.join("\n") + "\n";
+}
+
+/**
+ * Creates directory if it doesn't exist
+ */
+function ensureDirectoryExists(dirPath: string): void {
+    if (!fs.existsSync(dirPath)) {
+        fs.mkdirSync(dirPath, { recursive: true });
+    }
+}
+
+/**
+ * Main function to generate all fixtures
+ */
+async function generateFixtures(): Promise<void> {
+    console.log(`Generating ${TOTAL_COMPONENTS} components across ${TOTAL_MODULES} modules...`);
+    console.log(`Each module will contain ${COMPONENTS_PER_MODULE} components.`);
+    console.log(`Output directory: ${FIXTURES_DIR}`);
+
+    // Clean and create fixtures directory
+    if (fs.existsSync(FIXTURES_DIR)) {
+        fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+    }
+    ensureDirectoryExists(FIXTURES_DIR);
+
+    // Generate modules and components
+    for (let moduleIndex = 0; moduleIndex < TOTAL_MODULES; moduleIndex++) {
+        const moduleName = getModuleName(moduleIndex);
+        const moduleDir = path.join(FIXTURES_DIR, moduleName);
+
+        console.log(`Generating module ${moduleIndex + 1}/${TOTAL_MODULES}: ${moduleName}`);
+        ensureDirectoryExists(moduleDir);
+
+        // Generate components for this module
+        for (let componentIndex = 0; componentIndex < COMPONENTS_PER_MODULE; componentIndex++) {
+            const componentName = getComponentName(moduleIndex, componentIndex);
+            const componentContent = generateComponentContent(moduleIndex, componentIndex);
+            const componentPath = path.join(moduleDir, `${componentName}.tsx`);
+
+            fs.writeFileSync(componentPath, componentContent, "utf8");
+        }
+
+        // Generate barrel file for this module
+        const barrelContent = generateBarrelFileContent(moduleIndex);
+        const barrelPath = path.join(moduleDir, "index.ts");
+        fs.writeFileSync(barrelPath, barrelContent, "utf8");
+    }
+
+    console.log("✅ Fixture generation completed!");
+    console.log(`📁 Generated ${TOTAL_MODULES} modules with ${TOTAL_COMPONENTS} components`);
+    console.log(`📄 Each component has ~20 imports (5 same-module, 5 cross-module barrel, 5 aliased, 5 NPM)`);
+    console.log(`🎯 Ready for SWC plugin performance testing`);
+}
+
+generateFixtures().catch(console.error);

--- a/perf/run.ts
+++ b/perf/run.ts
@@ -1,0 +1,183 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+const FIXTURES_DIR = path.resolve(__dirname, "./fixtures");
+const OUTPUT_DIR = path.resolve(__dirname, "./output");
+const SWC_CONFIG_PATH = path.resolve(__dirname, ".swcrc");
+const ITERATIONS = 5;
+
+function generateSwcConfig(plugin: unknown): void {
+    const config = {
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                tsx: true,
+                decorators: false,
+                dynamicImport: false,
+            },
+            transform: {
+                react: {
+                    pragma: "React.createElement",
+                    pragmaFrag: "React.Fragment",
+                    throwIfNamespace: true,
+                    development: false,
+                    useBuiltins: false,
+                },
+            },
+            target: "es2022",
+            loose: false,
+            externalHelpers: false,
+            keepClassNames: false,
+            experimental: {
+                plugins: [plugin],
+            },
+        },
+        module: {
+            type: "es6",
+        },
+        minify: false,
+        isModule: true,
+    };
+
+    fs.writeFileSync(SWC_CONFIG_PATH, JSON.stringify(config, null, 4), "utf8");
+}
+
+function getBarrelFilesConfig(wasmPath: string) {
+    return [
+        wasmPath,
+        {
+            patterns: [
+                path.resolve(FIXTURES_DIR, "components/*/index.ts").replace(/\\/g, "/"),
+                path.resolve(FIXTURES_DIR, "utils/*/index.ts").replace(/\\/g, "/"),
+                path.resolve(FIXTURES_DIR, "hooks/*/index.ts").replace(/\\/g, "/"),
+                path.resolve(FIXTURES_DIR, "services/*/index.ts").replace(/\\/g, "/"),
+                path.resolve(FIXTURES_DIR, "*/index.ts").replace(/\\/g, "/"),
+            ],
+            aliases: [
+                {
+                    pattern: "#components/*",
+                    paths: [path.resolve(FIXTURES_DIR, "components/*/index.ts").replace(/\\/g, "/")],
+                },
+                {
+                    pattern: "#utils/*",
+                    paths: [path.resolve(FIXTURES_DIR, "utils/*/index.ts").replace(/\\/g, "/")],
+                },
+                {
+                    pattern: "#src/*",
+                    paths: [path.resolve(FIXTURES_DIR, "*/index.ts").replace(/\\/g, "/")],
+                },
+            ],
+            unsupported_import_mode: "error",
+            invalid_barrel_mode: "error",
+        },
+    ];
+}
+
+function runCompilation(plugin: unknown): { duration: number; success: boolean } {
+    generateSwcConfig(plugin);
+
+    fs.rmSync(OUTPUT_DIR, { recursive: true, force: true });
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+    const startTime = process.hrtime.bigint();
+
+    const command = `pnpm exec swc ${FIXTURES_DIR} -d ${OUTPUT_DIR} --config-file ${path.join(__dirname, ".swcrc")}`;
+
+    execSync(command, {
+        encoding: "utf8",
+        stdio: "pipe",
+        cwd: process.cwd(),
+    });
+
+    const endTime = process.hrtime.bigint();
+    const duration = Number(endTime - startTime) / 1_000_000;
+
+    return { duration, success: true };
+}
+
+type Config = { name: "BASE" | "CURRENT"; plugin: unknown };
+
+async function runBenchmark(configs: Config[]) {
+    const results: Record<Config["name"], number[]> = {
+        BASE: [],
+        CURRENT: [],
+    };
+
+    for (let i = 0; i < ITERATIONS; i++) {
+        for (const config of configs) {
+            console.log(`Running ${config.name} ${i + 1}...`);
+            const result = runCompilation(config.plugin);
+            results[config.name].push(result.duration);
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+    }
+
+    const averages: Record<string, number> = {};
+    for (const [name, durations] of Object.entries(results)) {
+        const average = durations.reduce((sum, duration) => sum + duration, 0) / durations.length;
+        averages[name] = average;
+        console.log(`${name} runs: ${durations.map((d) => (d / 1000).toFixed(2)).join("s, ")}s`);
+        console.log(`${name} average: ${(average / 1000).toFixed(2)}s`);
+    }
+
+    const baseAverage = averages.BASE || 0;
+    const currentAverage = averages.CURRENT || 0;
+
+    const baseTime = (baseAverage / 1000).toFixed(2);
+    const currentTime = (currentAverage / 1000).toFixed(2);
+
+    console.log(`\nSUMMARY:`);
+    console.log(`BASE:        ${baseTime}s`);
+    console.log(`CURRENT:     ${currentTime}s`);
+
+    const difference = currentAverage - baseAverage;
+    const percentChange = (difference / baseAverage) * 100;
+
+    const sign = difference > 0 ? "+" : "";
+    console.log(`Difference:  ${sign}${(difference / 1000).toFixed(2)}s (${sign}${percentChange.toFixed(1)}%)`);
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.includes("-h")) {
+    console.log("Usage: tsx perf/run.ts [options]");
+    console.log("Options:");
+    console.log("  --base <path>            Run benchmark against custom base build (provide WASM path)");
+    console.log("  --help, -h               Show this help message");
+    process.exit(0);
+}
+
+function getArgValue(argName: string): string | null {
+    const index = args.indexOf(argName);
+    if (index !== -1 && index + 1 < args.length) {
+        return args[index + 1];
+    }
+    return null;
+}
+
+const configs: Config[] = [];
+
+const baseIndex = args.indexOf("--base");
+if (baseIndex !== -1) {
+    let basePath = getArgValue("--base");
+    if (!basePath) {
+        console.error("Error: --base option requires a path to the WASM file");
+        process.exit(1);
+    }
+    basePath = path.resolve(process.cwd(), basePath);
+    if (!fs.existsSync(basePath)) {
+        console.error(`Error: Base WASM file not found at: ${basePath}`);
+        process.exit(1);
+    }
+    configs.push({ name: "BASE", plugin: getBarrelFilesConfig(basePath) });
+} else {
+    configs.push({ name: "BASE", plugin: ["@swc/plugin-noop", {}] });
+}
+
+configs.push({
+    name: "CURRENT",
+    plugin: getBarrelFilesConfig(path.join(__dirname, "../swc_plugin_barrel_files.wasm")),
+});
+
+runBenchmark(configs).catch(console.error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,21 +14,30 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.5
         version: 2.29.5
+      '@swc/cli':
+        specifier: 0.7.8
+        version: 0.7.8(@swc/core@1.12.11)
       '@swc/core':
         specifier: 1.12.11
         version: 1.12.11
+      '@swc/plugin-noop':
+        specifier: 9.0.0
+        version: 9.0.0
       '@types/node':
         specifier: 22.13.11
         version: 22.13.11
       prettier:
         specifier: 3.6.2
         version: 3.6.2
+      tsx:
+        specifier: 4.20.3
+        version: 4.20.3
       typescript:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
         specifier: 3.2.4
-        version: 3.2.4(@types/node@22.13.11)
+        version: 3.2.4(@types/node@22.13.11)(tsx@4.20.3)
 
 packages:
 
@@ -256,6 +265,106 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@napi-rs/nice-android-arm-eabi@1.0.4':
+    resolution: {integrity: sha512-OZFMYUkih4g6HCKTjqJHhMUlgvPiDuSLZPbPBWHLjKmFTv74COzRlq/gwHtmEVaR39mJQ6ZyttDl2HNMUbLVoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@napi-rs/nice-android-arm64@1.0.4':
+    resolution: {integrity: sha512-k8u7cjeA64vQWXZcRrPbmwjH8K09CBnNaPnI9L1D5N6iMPL3XYQzLcN6WwQonfcqCDv5OCY3IqX89goPTV4KMw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/nice-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-GsLdQvUcuVzoyzmtjsThnpaVEizAqH5yPHgnsBmq3JdVoVZHELFo7PuJEdfOH1DOHi2mPwB9sCJEstAYf3XCJA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/nice-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-1y3gyT3e5zUY5SxRl3QDtJiWVsbkmhtUHIYwdWWIQ3Ia+byd/IHIEpqAxOGW1nhhnIKfTCuxBadHQb+yZASVoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/nice-freebsd-x64@1.0.4':
+    resolution: {integrity: sha512-06oXzESPRdXUuzS8n2hGwhM2HACnDfl3bfUaSqLGImM8TA33pzDXgGL0e3If8CcFWT98aHows5Lk7xnqYNGFeA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/nice-linux-arm-gnueabihf@1.0.4':
+    resolution: {integrity: sha512-CgklZ6g8WL4+EgVVkxkEvvsi2DSLf9QIloxWO0fvQyQBp6VguUSX3eHLeRpqwW8cRm2Hv/Q1+PduNk7VK37VZw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/nice-linux-arm64-gnu@1.0.4':
+    resolution: {integrity: sha512-wdAJ7lgjhAlsANUCv0zi6msRwq+D4KDgU+GCCHssSxWmAERZa2KZXO0H2xdmoJ/0i03i6YfK/sWaZgUAyuW2oQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/nice-linux-arm64-musl@1.0.4':
+    resolution: {integrity: sha512-4b1KYG+sriufhFrpUS9uNOEYYJqSfcbnwGx6uGX7JjrH8tELG90cOpCawz5THNIwlS3DhLgnCOcn0+4p6z26QA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/nice-linux-ppc64-gnu@1.0.4':
+    resolution: {integrity: sha512-iaf3vMRgr23oe1PUaKpxaH3DS0IMN0+N9iEiWVwYPm/U15vZFYdqVegGfN2PzrZLUl5lc8ZxbmEKDfuqslhAMA==}
+    engines: {node: '>= 10'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@napi-rs/nice-linux-riscv64-gnu@1.0.4':
+    resolution: {integrity: sha512-UXoREY6Yw6rHrGuTwQgBxpfjK34t6mTjibE9/cXbefL9AuUCJ9gEgwNKZiONuR5QGswChqo9cnthjdKkYyAdDg==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/nice-linux-s390x-gnu@1.0.4':
+    resolution: {integrity: sha512-eFbgYCRPmsqbYPAlLYU5hYTNbogmIDUvknilehHsFhCH1+0/kN87lP+XaLT0Yeq4V/rpwChSd9vlz4muzFArtw==}
+    engines: {node: '>= 10'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@napi-rs/nice-linux-x64-gnu@1.0.4':
+    resolution: {integrity: sha512-4T3E6uTCwWT6IPnwuPcWVz3oHxvEp/qbrCxZhsgzwTUBEwu78EGNXGdHfKJQt3soth89MLqZJw+Zzvnhrsg1mQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/nice-linux-x64-musl@1.0.4':
+    resolution: {integrity: sha512-NtbBkAeyBPLvCBkWtwkKXkNSn677eaT0cX3tygq+2qVv71TmHgX4gkX6o9BXjlPzdgPGwrUudavCYPT9tzkEqQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/nice-win32-arm64-msvc@1.0.4':
+    resolution: {integrity: sha512-vubOe3i+YtSJGEk/++73y+TIxbuVHi+W8ZzrRm2eETCjCRwNlgbfToQZ85dSA+4iBB/NJRGNp+O4hfdbbttZWA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/nice-win32-ia32-msvc@1.0.4':
+    resolution: {integrity: sha512-BMOVrUDZeg1RNRKVlh4eyLv5djAAVLiSddfpuuQ47EFjBcklg0NUeKMFKNrKQR4UnSn4HAiACLD7YK7koskwmg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/nice-win32-x64-msvc@1.0.4':
+    resolution: {integrity: sha512-kCNk6HcRZquhw/whwh4rHsdPyOSCQCgnVDVik+Y9cuSVTDy3frpiCJTScJqPPS872h4JgZKkr/+CwcwttNEo9Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/nice@1.0.4':
+    resolution: {integrity: sha512-Sqih1YARrmMoHlXGgI9JrrgkzxcaaEso0AH+Y7j8NHonUs+xe4iDsgC3IBIDNdzEewbNpccNN6hip+b5vmyRLw==}
+    engines: {node: '>= 10'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -368,6 +477,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sindresorhus/is@5.6.0':
+    resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
+    engines: {node: '>=14.16'}
+
+  '@swc/cli@0.7.8':
+    resolution: {integrity: sha512-27Ov4rm0s2C6LLX+NDXfDVB69LGs8K94sXtFhgeUyQ4DBywZuCgTBu2loCNHRr8JhT9DeQvJM5j9FAu/THbo4w==}
+    engines: {node: '>= 16.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1.2.66
+      chokidar: ^4.0.1
+    peerDependenciesMeta:
+      chokidar:
+        optional: true
+
   '@swc/core-darwin-arm64@1.12.11':
     resolution: {integrity: sha512-J19Jj9Y5x/N0loExH7W0OI9OwwoVyxutDdkyq1o/kgXyBqmmzV7Y/Q9QekI2Fm/qc5mNeAdP7aj4boY4AY/JPw==}
     engines: {node: '>=10'}
@@ -440,8 +564,22 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
+  '@swc/plugin-noop@9.0.0':
+    resolution: {integrity: sha512-pVuIdzdWSATlHkFW7FP5iHkiWfzVVcaroNv0VUogiCZlnECJU37Nk3GSUeGwhRHwSs+OkvMIPJ95U7gsibiofw==}
+
   '@swc/types@0.1.23':
     resolution: {integrity: sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==}
+
+  '@szmarczak/http-timer@5.0.1':
+    resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
+    engines: {node: '>=14.16'}
+
+  '@tokenizer/inflate@0.2.7':
+    resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
@@ -451,6 +589,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/http-cache-semantics@4.0.4':
+    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -487,6 +628,46 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  '@xhmikosr/archive-type@7.1.0':
+    resolution: {integrity: sha512-xZEpnGplg1sNPyEgFh0zbHxqlw5dtYg6viplmWSxUj12+QjU9SKu3U/2G73a15pEjLaOqTefNSZ1fOPUOT4Xgg==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/bin-check@7.1.0':
+    resolution: {integrity: sha512-y1O95J4mnl+6MpVmKfMYXec17hMEwE/yeCglFNdx+QvLLtP0yN4rSYcbkXnth+lElBuKKek2NbvOfOGPpUXCvw==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/bin-wrapper@13.1.1':
+    resolution: {integrity: sha512-93iXrknsWrP3G6QJBCJVz4xftMe5ZNJMWyOjtiug74k8dmQA4blfmaBcBgJUCYfSSQnjxjMNqxfincVuWbcGLA==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/decompress-tar@8.1.0':
+    resolution: {integrity: sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/decompress-tarbz2@8.1.0':
+    resolution: {integrity: sha512-aCLfr3A/FWZnOu5eqnJfme1Z1aumai/WRw55pCvBP+hCGnTFrcpsuiaVN5zmWTR53a8umxncY2JuYsD42QQEbw==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/decompress-targz@8.1.0':
+    resolution: {integrity: sha512-fhClQ2wTmzxzdz2OhSQNo9ExefrAagw93qaG1YggoIz/QpI7atSRa7eOHv4JZkpHWs91XNn8Hry3CwUlBQhfPA==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/decompress-unzip@7.1.0':
+    resolution: {integrity: sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/decompress@10.1.0':
+    resolution: {integrity: sha512-jmVnzuJYX4f89Ls63CRI5s0GrWpLUqo+vY+8YrXuFiebDcF3xFwiSVCie68LrJNltSYMLcDY60JN51H/lVTw6Q==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/downloader@15.1.1':
+    resolution: {integrity: sha512-zRj8cT8KbXigN5bJz9QszeyR1Jsc4HOizjLOB5FspQ0COvKpoAOq/OUYAI5b0Pt4pfeSyc6F5iHvdGCg8Him8Q==}
+    engines: {node: '>=18'}
+
+  '@xhmikosr/os-filter-obj@3.0.0':
+    resolution: {integrity: sha512-siPY6BD5dQ2SZPl3I0OZBHL27ZqZvLEosObsZRQ1NUB8qcxegwt0T9eKtV96JMFQpIz1elhkzqOg4c/Ri6Dp9A==}
+    engines: {node: ^14.14.0 || >=16.0.0}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -494,6 +675,9 @@ packages:
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  arch@3.0.0:
+    resolution: {integrity: sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -506,17 +690,54 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  b4a@1.6.7:
+    resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.6.0:
+    resolution: {integrity: sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bin-version-check@5.1.0:
+    resolution: {integrity: sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==}
+    engines: {node: '>=12'}
+
+  bin-version@6.0.0:
+    resolution: {integrity: sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==}
+    engines: {node: '>=12'}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacheable-lookup@7.0.0:
+    resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
+    engines: {node: '>=14.16'}
+
+  cacheable-request@10.2.14:
+    resolution: {integrity: sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==}
+    engines: {node: '>=14.16'}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -532,6 +753,18 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -549,9 +782,21 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  defaults@2.0.2:
+    resolution: {integrity: sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==}
+    engines: {node: '>=16'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -585,9 +830,21 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   expect-type@1.2.1:
     resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
     engines: {node: '>=12.0.0'}
+
+  ext-list@2.2.2:
+    resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
+    engines: {node: '>=0.10.0'}
+
+  ext-name@5.0.0:
+    resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
+    engines: {node: '>=4'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -595,6 +852,9 @@ packages:
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -611,6 +871,21 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  file-type@20.5.0:
+    resolution: {integrity: sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==}
+    engines: {node: '>=18'}
+
+  filename-reserved-regex@3.0.0:
+    resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  filenamify@6.0.0:
+    resolution: {integrity: sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==}
+    engines: {node: '>=16'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -618,6 +893,14 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  find-versions@5.1.0:
+    resolution: {integrity: sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==}
+    engines: {node: '>=12'}
+
+  form-data-encoder@2.1.4:
+    resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
+    engines: {node: '>= 14.17'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -632,6 +915,13 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -640,20 +930,41 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  got@13.0.0:
+    resolution: {integrity: sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==}
+    engines: {node: '>=16'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
 
   human-id@4.1.1:
     resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
     hasBin: true
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
+
+  inspect-with-kind@1.0.5:
+    resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -666,6 +977,14 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -685,8 +1004,18 @@ packages:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -701,8 +1030,19 @@ packages:
   loupe@3.1.4:
     resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
 
+  lowercase-keys@3.0.0:
+    resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -711,6 +1051,26 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  mimic-response@4.0.0:
+    resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -733,12 +1093,28 @@ packages:
       encoding:
         optional: true
 
+  normalize-url@8.0.2:
+    resolution: {integrity: sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==}
+    engines: {node: '>=14.16'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  p-cancelable@3.0.0:
+    resolution: {integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==}
+    engines: {node: '>=12.20'}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -782,6 +1158,9 @@ packages:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -796,6 +1175,9 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  piscina@4.9.2:
+    resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -817,6 +1199,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
@@ -824,9 +1210,19 @@ packages:
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  responselike@3.0.0:
+    resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
+    engines: {node: '>=14.16'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -840,8 +1236,23 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  seek-bzip@2.0.0:
+    resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
+    hasBin: true
+
+  semver-regex@4.0.5:
+    resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
+    engines: {node: '>=12'}
+
+  semver-truncate@3.0.0:
+    resolution: {integrity: sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==}
+    engines: {node: '>=12'}
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
@@ -859,6 +1270,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -867,9 +1281,21 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sort-keys-length@1.0.1:
+    resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
+    engines: {node: '>=0.10.0'}
+
+  sort-keys@1.1.2:
+    resolution: {integrity: sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==}
+    engines: {node: '>=0.10.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -883,6 +1309,9 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  streamx@2.22.1:
+    resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -891,12 +1320,32 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-dirs@3.0.0:
+    resolution: {integrity: sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.3:
+    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -928,13 +1377,29 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  token-types@6.0.4:
+    resolution: {integrity: sha512-MD9MjpVNhVyH4fyd5rKphjvt/1qj+PtQUz65aFqAZA6XniWAuSFRjLk3e2VALEFlh9OwBpXUN7rfeqSnT/Fmkw==}
+    engines: {node: '>=14.16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.4.0:
+    resolution: {integrity: sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==}
+    engines: {node: '>=18'}
+
+  unbzip2-stream@1.4.3:
+    resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -1031,6 +1496,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  yauzl@3.2.0:
+    resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
+    engines: {node: '>=12'}
 
 snapshots:
 
@@ -1288,6 +1757,74 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@napi-rs/nice-android-arm-eabi@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-android-arm64@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-darwin-arm64@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-darwin-x64@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-freebsd-x64@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-arm-gnueabihf@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-arm64-gnu@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-arm64-musl@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-ppc64-gnu@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-riscv64-gnu@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-s390x-gnu@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-x64-gnu@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-linux-x64-musl@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-win32-arm64-msvc@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-win32-ia32-msvc@1.0.4':
+    optional: true
+
+  '@napi-rs/nice-win32-x64-msvc@1.0.4':
+    optional: true
+
+  '@napi-rs/nice@1.0.4':
+    optionalDependencies:
+      '@napi-rs/nice-android-arm-eabi': 1.0.4
+      '@napi-rs/nice-android-arm64': 1.0.4
+      '@napi-rs/nice-darwin-arm64': 1.0.4
+      '@napi-rs/nice-darwin-x64': 1.0.4
+      '@napi-rs/nice-freebsd-x64': 1.0.4
+      '@napi-rs/nice-linux-arm-gnueabihf': 1.0.4
+      '@napi-rs/nice-linux-arm64-gnu': 1.0.4
+      '@napi-rs/nice-linux-arm64-musl': 1.0.4
+      '@napi-rs/nice-linux-ppc64-gnu': 1.0.4
+      '@napi-rs/nice-linux-riscv64-gnu': 1.0.4
+      '@napi-rs/nice-linux-s390x-gnu': 1.0.4
+      '@napi-rs/nice-linux-x64-gnu': 1.0.4
+      '@napi-rs/nice-linux-x64-musl': 1.0.4
+      '@napi-rs/nice-win32-arm64-msvc': 1.0.4
+      '@napi-rs/nice-win32-ia32-msvc': 1.0.4
+      '@napi-rs/nice-win32-x64-msvc': 1.0.4
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1360,6 +1897,23 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
 
+  '@sindresorhus/is@5.6.0': {}
+
+  '@swc/cli@0.7.8(@swc/core@1.12.11)':
+    dependencies:
+      '@swc/core': 1.12.11
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 13.1.1
+      commander: 8.3.0
+      minimatch: 9.0.5
+      piscina: 4.9.2
+      semver: 7.7.1
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.14
+    transitivePeerDependencies:
+      - supports-color
+
   '@swc/core-darwin-arm64@1.12.11':
     optional: true
 
@@ -1408,9 +1962,27 @@ snapshots:
 
   '@swc/counter@0.1.3': {}
 
+  '@swc/plugin-noop@9.0.0':
+    dependencies:
+      '@swc/counter': 0.1.3
+
   '@swc/types@0.1.23':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@szmarczak/http-timer@5.0.1':
+    dependencies:
+      defer-to-connect: 2.0.1
+
+  '@tokenizer/inflate@0.2.7':
+    dependencies:
+      debug: 4.4.1
+      fflate: 0.8.2
+      token-types: 6.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
 
   '@types/chai@5.2.2':
     dependencies:
@@ -1419,6 +1991,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.7': {}
+
+  '@types/http-cache-semantics@4.0.4': {}
 
   '@types/node@12.20.55': {}
 
@@ -1434,13 +2008,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.2.5(@types/node@22.13.11))':
+  '@vitest/mocker@3.2.4(vite@6.2.5(@types/node@22.13.11)(tsx@4.20.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.5(@types/node@22.13.11)
+      vite: 6.2.5(@types/node@22.13.11)(tsx@4.20.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1468,9 +2042,95 @@ snapshots:
       loupe: 3.1.4
       tinyrainbow: 2.0.0
 
+  '@xhmikosr/archive-type@7.1.0':
+    dependencies:
+      file-type: 20.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/bin-check@7.1.0':
+    dependencies:
+      execa: 5.1.1
+      isexe: 2.0.0
+
+  '@xhmikosr/bin-wrapper@13.1.1':
+    dependencies:
+      '@xhmikosr/bin-check': 7.1.0
+      '@xhmikosr/downloader': 15.1.1
+      '@xhmikosr/os-filter-obj': 3.0.0
+      bin-version-check: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/decompress-tar@8.1.0':
+    dependencies:
+      file-type: 20.5.0
+      is-stream: 2.0.1
+      tar-stream: 3.1.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/decompress-tarbz2@8.1.0':
+    dependencies:
+      '@xhmikosr/decompress-tar': 8.1.0
+      file-type: 20.5.0
+      is-stream: 2.0.1
+      seek-bzip: 2.0.0
+      unbzip2-stream: 1.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/decompress-targz@8.1.0':
+    dependencies:
+      '@xhmikosr/decompress-tar': 8.1.0
+      file-type: 20.5.0
+      is-stream: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/decompress-unzip@7.1.0':
+    dependencies:
+      file-type: 20.5.0
+      get-stream: 6.0.1
+      yauzl: 3.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/decompress@10.1.0':
+    dependencies:
+      '@xhmikosr/decompress-tar': 8.1.0
+      '@xhmikosr/decompress-tarbz2': 8.1.0
+      '@xhmikosr/decompress-targz': 8.1.0
+      '@xhmikosr/decompress-unzip': 7.1.0
+      graceful-fs: 4.2.11
+      make-dir: 4.0.0
+      strip-dirs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/downloader@15.1.1':
+    dependencies:
+      '@xhmikosr/archive-type': 7.1.0
+      '@xhmikosr/decompress': 10.1.0
+      content-disposition: 0.5.4
+      defaults: 2.0.2
+      ext-name: 5.0.0
+      file-type: 20.5.0
+      filenamify: 6.0.0
+      get-stream: 6.0.1
+      got: 13.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@xhmikosr/os-filter-obj@3.0.0':
+    dependencies:
+      arch: 3.0.0
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
+
+  arch@3.0.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -1480,15 +2140,58 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  b4a@1.6.7: {}
+
+  balanced-match@1.0.2: {}
+
+  bare-events@2.6.0:
+    optional: true
+
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bin-version-check@5.1.0:
+    dependencies:
+      bin-version: 6.0.0
+      semver: 7.7.1
+      semver-truncate: 3.0.0
+
+  bin-version@6.0.0:
+    dependencies:
+      execa: 5.1.1
+      find-versions: 5.1.0
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
+  buffer-crc32@0.2.13: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   cac@6.7.14: {}
+
+  cacheable-lookup@7.0.0: {}
+
+  cacheable-request@10.2.14:
+    dependencies:
+      '@types/http-cache-semantics': 4.0.4
+      get-stream: 6.0.1
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      mimic-response: 4.0.0
+      normalize-url: 8.0.2
+      responselike: 3.0.0
 
   chai@5.2.0:
     dependencies:
@@ -1504,6 +2207,14 @@ snapshots:
 
   ci-info@3.9.0: {}
 
+  commander@6.2.1: {}
+
+  commander@8.3.0: {}
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -1516,7 +2227,15 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  defaults@2.0.2: {}
+
+  defer-to-connect@2.0.1: {}
 
   detect-indent@6.1.0: {}
 
@@ -1567,7 +2286,28 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.7
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   expect-type@1.2.1: {}
+
+  ext-list@2.2.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ext-name@5.0.0:
+    dependencies:
+      ext-list: 2.2.2
+      sort-keys-length: 1.0.1
 
   extendable-error@0.1.7: {}
 
@@ -1576,6 +2316,8 @@ snapshots:
       chardet: 0.7.0
       iconv-lite: 0.4.24
       tmp: 0.0.33
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -1593,6 +2335,23 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fflate@0.8.2: {}
+
+  file-type@20.5.0:
+    dependencies:
+      '@tokenizer/inflate': 0.2.7
+      strtok3: 10.3.4
+      token-types: 6.0.4
+      uint8array-extras: 1.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  filename-reserved-regex@3.0.0: {}
+
+  filenamify@6.0.0:
+    dependencies:
+      filename-reserved-regex: 3.0.0
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -1601,6 +2360,12 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  find-versions@5.1.0:
+    dependencies:
+      semver-regex: 4.0.5
+
+  form-data-encoder@2.1.4: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -1617,6 +2382,12 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-stream@6.0.1: {}
+
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -1630,15 +2401,44 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  got@13.0.0:
+    dependencies:
+      '@sindresorhus/is': 5.6.0
+      '@szmarczak/http-timer': 5.0.1
+      cacheable-lookup: 7.0.0
+      cacheable-request: 10.2.14
+      decompress-response: 6.0.0
+      form-data-encoder: 2.1.4
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 3.0.0
+      p-cancelable: 3.0.0
+      responselike: 3.0.0
+
   graceful-fs@4.2.11: {}
 
+  http-cache-semantics@4.2.0: {}
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
   human-id@4.1.1: {}
+
+  human-signals@2.1.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
+
+  inspect-with-kind@1.0.5:
+    dependencies:
+      kind-of: 6.0.3
 
   is-extglob@2.1.1: {}
 
@@ -1647,6 +2447,10 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-plain-obj@1.1.0: {}
+
+  is-stream@2.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -1663,9 +2467,17 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
+  json-buffer@3.0.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -1677,9 +2489,17 @@ snapshots:
 
   loupe@3.1.4: {}
 
+  lowercase-keys@3.0.0: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.1
+
+  merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -1687,6 +2507,18 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.54.0: {}
+
+  mimic-fn@2.1.0: {}
+
+  mimic-response@3.1.0: {}
+
+  mimic-response@4.0.0: {}
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
 
   mri@1.2.0: {}
 
@@ -1698,9 +2530,21 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  normalize-url@8.0.2: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  p-cancelable@3.0.0: {}
 
   p-filter@2.1.0:
     dependencies:
@@ -1732,6 +2576,8 @@ snapshots:
 
   pathval@2.0.0: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -1739,6 +2585,10 @@ snapshots:
   picomatch@4.0.2: {}
 
   pify@4.0.1: {}
+
+  piscina@4.9.2:
+    optionalDependencies:
+      '@napi-rs/nice': 1.0.4
 
   postcss@8.5.3:
     dependencies:
@@ -1754,6 +2604,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-lru@5.1.1: {}
+
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -1763,7 +2615,15 @@ snapshots:
 
   regenerator-runtime@0.14.1: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  responselike@3.0.0:
+    dependencies:
+      lowercase-keys: 3.0.0
 
   reusify@1.1.0: {}
 
@@ -1797,7 +2657,19 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
+
+  seek-bzip@2.0.0:
+    dependencies:
+      commander: 6.2.1
+
+  semver-regex@4.0.5: {}
+
+  semver-truncate@3.0.0:
+    dependencies:
+      semver: 7.7.1
 
   semver@7.7.1: {}
 
@@ -1809,11 +2681,23 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
 
+  sort-keys-length@1.0.1:
+    dependencies:
+      sort-keys: 1.1.2
+
+  sort-keys@1.1.2:
+    dependencies:
+      is-plain-obj: 1.1.0
+
   source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -1826,17 +2710,47 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  streamx@2.22.1:
+    dependencies:
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.3
+    optionalDependencies:
+      bare-events: 2.6.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
 
+  strip-dirs@3.0.0:
+    dependencies:
+      inspect-with-kind: 1.0.5
+      is-plain-obj: 1.1.0
+
+  strip-final-newline@2.0.0: {}
+
   strip-literal@3.0.0:
     dependencies:
       js-tokens: 9.0.1
 
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.6.7
+      fast-fifo: 1.3.2
+      streamx: 2.22.1
+
   term-size@2.2.1: {}
+
+  text-decoder@1.2.3:
+    dependencies:
+      b4a: 1.6.7
+
+  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -1861,21 +2775,40 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  token-types@6.0.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   tr46@0.0.3: {}
 
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.2
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.8.3: {}
+
+  uint8array-extras@1.4.0: {}
+
+  unbzip2-stream@1.4.3:
+    dependencies:
+      buffer: 5.7.1
+      through: 2.3.8
 
   undici-types@6.20.0: {}
 
   universalify@0.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.13.11):
+  vite-node@3.2.4(@types/node@22.13.11)(tsx@4.20.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.5(@types/node@22.13.11)
+      vite: 6.2.5(@types/node@22.13.11)(tsx@4.20.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1890,7 +2823,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.5(@types/node@22.13.11):
+  vite@6.2.5(@types/node@22.13.11)(tsx@4.20.3):
     dependencies:
       esbuild: 0.25.2
       postcss: 8.5.3
@@ -1898,12 +2831,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.11
       fsevents: 2.3.3
+      tsx: 4.20.3
 
-  vitest@3.2.4(@types/node@22.13.11):
+  vitest@3.2.4(@types/node@22.13.11)(tsx@4.20.3):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.2.5(@types/node@22.13.11))
+      '@vitest/mocker': 3.2.4(vite@6.2.5(@types/node@22.13.11)(tsx@4.20.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1921,8 +2855,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.2.5(@types/node@22.13.11)
-      vite-node: 3.2.4(@types/node@22.13.11)
+      vite: 6.2.5(@types/node@22.13.11)(tsx@4.20.3)
+      vite-node: 3.2.4(@types/node@22.13.11)(tsx@4.20.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.11
@@ -1955,3 +2889,8 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yauzl@3.2.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,17 @@
 use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
 use std::fmt;
 
 /// Mode for handling unsupported import patterns
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UnsupportedImportMode {
     /// Throw an error and stop compilation
+    #[default]
     Error,
     /// Print a warning and skip the import
     Warn,
     /// Silently skip the import
     Off,
-}
-
-impl Default for UnsupportedImportMode {
-    fn default() -> Self {
-        UnsupportedImportMode::Error
-    }
 }
 
 impl fmt::Display for UnsupportedImportMode {
@@ -47,20 +43,15 @@ impl<'de> Deserialize<'de> for UnsupportedImportMode {
 }
 
 /// Mode for handling invalid barrel files
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum InvalidBarrelMode {
     /// Throw an error and stop compilation
+    #[default]
     Error,
     /// Print a warning and skip the import
     Warn,
     /// Silently skip the import
     Off,
-}
-
-impl Default for InvalidBarrelMode {
-    fn default() -> Self {
-        InvalidBarrelMode::Error
-    }
 }
 
 impl fmt::Display for InvalidBarrelMode {
@@ -99,6 +90,9 @@ pub struct Config {
 
     /// Rules for resolving import aliases (optional)
     pub aliases: Option<Vec<Alias>>,
+
+    /// Symlink mappings from external paths to internal paths (optional)
+    pub symlinks: Option<HashMap<String, String>>,
 
     /// Enables debug logging to stdout
     pub debug: Option<bool>,

--- a/src/import_transformer.rs
+++ b/src/import_transformer.rs
@@ -201,7 +201,12 @@ pub fn transform_import(
 
         // Create new import declarations for each source path
         let mut result = Vec::new();
-        for (source_path, specifiers) in new_imports {
+
+        // Sort the imports by source path for deterministic output
+        let mut sorted_imports: Vec<_> = new_imports.into_iter().collect();
+        sorted_imports.sort_by(|a, b| a.0.cmp(&b.0));
+
+        for (source_path, specifiers) in sorted_imports {
             let new_import = ImportDecl {
                 span: import_decl.span,
                 specifiers,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 mod alias_resolver;
 mod config;
 mod import_transformer;
+mod path_resolver;
 mod paths;
 mod pattern_matcher;
 mod re_export;

--- a/src/path_resolver.rs
+++ b/src/path_resolver.rs
@@ -1,0 +1,286 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::paths::{normalize_path, path_join};
+
+/// Virtual filesystem root directory
+const SWC_VIRTUAL_FS_ROOT_DIR: &str = "/cwd";
+
+/// Handles path resolution including symlink mappings
+#[derive(Clone)]
+pub struct PathResolver {
+    /// Compilation working directory
+    cwd: String,
+
+    /// Map of external paths to internal symlinked paths
+    symlinks: HashMap<String, String>,
+}
+
+impl PathResolver {
+    /// Creates a new PathResolver with the given configuration
+    pub fn new(symlinks: &Option<HashMap<String, String>>, cwd: &str) -> Self {
+        let symlinks = symlinks.clone().unwrap_or_default();
+
+        Self {
+            cwd: cwd.into(),
+            symlinks,
+        }
+    }
+
+    /// Resolves a path, applying symlink mappings if applicable
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to resolve
+    ///
+    /// # Returns
+    ///
+    /// The resolved path, or the original path if no symlink mapping applies
+    pub fn resolve_path(&self, path: &str) -> String {
+        // First, try exact file-level symlink matches (highest priority)
+        if let Some(symlinked_path) = self.symlinks.get(path) {
+            return symlinked_path.clone();
+        }
+
+        // Then, try directory-level symlink matches
+        for (external_path, internal_path) in &self.symlinks {
+            if let Some(resolved) = self.try_directory_symlink(path, external_path, internal_path) {
+                return resolved;
+            }
+        }
+
+        // No symlink mapping found, return original path
+        path.to_string()
+    }
+
+    /// Attempts to resolve a path using directory-level symlinks
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to resolve
+    /// * `external_dir` - The external directory path in the symlink mapping
+    /// * `internal_dir` - The internal directory path in the symlink mapping
+    ///
+    /// # Returns
+    ///
+    /// The resolved path if the path is within the external directory, None otherwise
+    fn try_directory_symlink(
+        &self,
+        path: &str,
+        external_dir: &str,
+        internal_dir: &str,
+    ) -> Option<String> {
+        // Normalize paths to handle trailing slashes consistently
+        let normalized_external = self.normalize_directory_path(external_dir);
+        let normalized_path = normalize_path(Path::new(path));
+
+        // Check if the path starts with the external directory
+        if normalized_path.starts_with(&normalized_external) {
+            // Calculate the relative path within the external directory
+            let relative_path = if normalized_path.len() > normalized_external.len() {
+                let separator_offset = if normalized_external.ends_with('/') {
+                    0
+                } else {
+                    1
+                };
+                &normalized_path[normalized_external.len() + separator_offset..]
+            } else {
+                ""
+            };
+
+            // Join the internal directory with the relative path
+            if relative_path.is_empty() {
+                Some(internal_dir.to_string())
+            } else {
+                Some(path_join(internal_dir, relative_path))
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Normalizes a directory path by ensuring consistent trailing slash handling
+    ///
+    /// # Arguments
+    ///
+    /// * `dir_path` - The directory path to normalize
+    ///
+    /// # Returns
+    ///
+    /// The normalized directory path
+    fn normalize_directory_path(&self, dir_path: &str) -> String {
+        let normalized = normalize_path(Path::new(dir_path));
+        if normalized.ends_with('/') && normalized.len() > 1 {
+            normalized[..normalized.len() - 1].to_string()
+        } else {
+            normalized
+        }
+    }
+
+    /// Resolves a path to a virtual path
+    ///
+    /// # Arguments
+    ///
+    /// * `cwd` - Compilation working directory
+    /// * `path` - The path to resolve
+    ///
+    /// # Returns
+    ///
+    /// The resolved virtual path
+    pub fn to_virtual_path(&self, path: &str) -> Result<String, String> {
+        if path.starts_with(&self.cwd) {
+            let without_cwd = &path[self.cwd.len() + 1..];
+            let result = path_join(SWC_VIRTUAL_FS_ROOT_DIR, without_cwd);
+            return Ok(result);
+        }
+
+        if Path::new(&path).is_absolute() {
+            return Err(format!(
+                "E_INVALID_FILE_PATH: Absolute paths not starting with cwd are not supported: {}",
+                path
+            ));
+        }
+
+        let result = path_join(SWC_VIRTUAL_FS_ROOT_DIR, path);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_file_symlink_resolution() {
+        let mut symlinks = HashMap::new();
+        symlinks.insert(
+            "../external/components/index.ts".to_string(),
+            "/cwd/src/ui/index.ts".to_string(),
+        );
+
+        let resolver = PathResolver::new(&Some(symlinks), "/cwd");
+
+        let resolved = resolver.resolve_path("../external/components/index.ts");
+        assert_eq!(resolved, "/cwd/src/ui/index.ts");
+    }
+
+    #[test]
+    fn test_directory_symlink_resolution() {
+        let mut symlinks = HashMap::new();
+        symlinks.insert(
+            "../external/components".to_string(),
+            "/cwd/src/ui".to_string(),
+        );
+
+        let resolver = PathResolver::new(&Some(symlinks), "/cwd");
+
+        let resolved = resolver.resolve_path("../external/components/Button/index.ts");
+        assert_eq!(resolved, "/cwd/src/ui/Button/index.ts");
+    }
+
+    #[test]
+    fn test_directory_symlink_with_trailing_slash() {
+        let mut symlinks = HashMap::new();
+        symlinks.insert(
+            "../external/components/".to_string(),
+            "/cwd/src/ui".to_string(),
+        );
+
+        let resolver = PathResolver::new(&Some(symlinks), "/cwd");
+
+        let resolved = resolver.resolve_path("../external/components/Button/index.ts");
+        assert_eq!(resolved, "/cwd/src/ui/Button/index.ts");
+    }
+
+    #[test]
+    fn test_file_symlink_priority_over_directory() {
+        let mut symlinks = HashMap::new();
+        symlinks.insert(
+            "../external/components".to_string(),
+            "/cwd/src/ui".to_string(),
+        );
+        symlinks.insert(
+            "../external/components/Button/index.ts".to_string(),
+            "/cwd/src/special/index.ts".to_string(),
+        );
+
+        let resolver = PathResolver::new(&Some(symlinks), "/cwd");
+
+        // Specific file symlink should take priority
+        let resolved = resolver.resolve_path("../external/components/Button/index.ts");
+        assert_eq!(resolved, "/cwd/src/special/index.ts");
+
+        // Other files should use directory symlink
+        let resolved2 = resolver.resolve_path("../external/components/Input/index.ts");
+        assert_eq!(resolved2, "/cwd/src/ui/Input/index.ts");
+    }
+
+    #[test]
+    fn test_no_symlink_match() {
+        let mut symlinks = HashMap::new();
+        symlinks.insert(
+            "../external/components".to_string(),
+            "/cwd/src/ui".to_string(),
+        );
+
+        let resolver = PathResolver::new(&Some(symlinks), "/cwd");
+
+        let resolved = resolver.resolve_path("../other/path/index.ts");
+        assert_eq!(resolved, "../other/path/index.ts");
+    }
+
+    #[test]
+    fn test_empty_symlinks() {
+        let resolver = PathResolver::new(&Some(HashMap::new()), "/cwd");
+
+        let resolved = resolver.resolve_path("../external/file.ts");
+        assert_eq!(resolved, "../external/file.ts");
+    }
+
+    #[test]
+    fn test_nested_directory_symlinks() {
+        let mut symlinks = HashMap::new();
+        symlinks.insert(
+            "../../shared/workspace/features".to_string(),
+            "/cwd/src/features".to_string(),
+        );
+
+        let resolver = PathResolver::new(&Some(symlinks), "/cwd");
+
+        let resolved = resolver.resolve_path("../../shared/workspace/features/auth/api/index.ts");
+        assert_eq!(resolved, "/cwd/src/features/auth/api/index.ts");
+    }
+
+    #[test]
+    fn test_resolve_to_virtual_path() {
+        let cwd = "/home/user/project";
+        let resolver = PathResolver::new(&Some(HashMap::new()), cwd);
+
+        // Test with path starting with cwd
+        let path = "/home/user/project/src/main.rs";
+        assert_eq!(resolver.to_virtual_path(path).unwrap(), "/cwd/src/main.rs");
+
+        // Test with relative path
+        let path = "src/main.rs";
+        assert_eq!(resolver.to_virtual_path(path).unwrap(), "/cwd/src/main.rs");
+
+        // Test with relative path starting with ./
+        let path = "./src/main.rs";
+        assert_eq!(resolver.to_virtual_path(path).unwrap(), "/cwd/src/main.rs");
+
+        // Test with nested ./ in the path
+        let path = "tests/./fixtures/src/features/f1/index.ts";
+        assert_eq!(
+            resolver.to_virtual_path(path).unwrap(),
+            "/cwd/tests/fixtures/src/features/f1/index.ts"
+        );
+
+        // Test with absolute path not starting with cwd
+        let path = "/other/path/file.rs";
+        assert!(resolver.to_virtual_path(path).is_err());
+        assert_eq!(
+            resolver.to_virtual_path(path).unwrap_err(),
+            "E_INVALID_FILE_PATH: Absolute paths not starting with cwd are not supported: /other/path/file.rs"
+        );
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "skipLibCheck": true
-    }
+    },
+    "exclude": ["perf/fixtures", "perf/output"]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -29,6 +29,17 @@ export interface PluginConfig {
      */
     aliases?: AliasConfig[];
     /**
+     * An optional mapping of external paths to internal symlinked paths.
+     * This allows the plugin to process barrel files from external locations
+     * by mapping them to internal symlinked paths within the current working directory.
+     *
+     * @example
+     * {
+     *   "../shared-workspace/some-pkg/src/features": "./node_modules/some-pkg/src/features"
+     * }
+     */
+    symlinks?: Record<string, string>;
+    /**
      * Enables debug logging to stdout.
      * @default false
      */


### PR DESCRIPTION
Add symlinks configuration support for external barrel files

This feature introduces a new `symlinks` configuration option that enables the plugin to work with external files and directories outside the current working directory. This is particularly useful in monorepo setups or when working with external libraries that need barrel file optimization.

This feature overcomes SWC plugin limitations that restrict file access to the current working directory, enabling barrel file optimization for shared workspace modules.

**Configuration Example:**

```json
{
    "symlinks": {
        "../external-lib/index.ts": "./node_modules/external-lib/index.ts",
        "../shared-workspace": "./symlinks/workspace/src"
    }
}
```

**How it Works:**

When the plugin encounters an import from an external path, it:

1. Checks if the path matches any symlink mapping
2. Resolves it to the internal symlinked path
3. Processes the barrel file using the internal path
4. Generates optimized direct imports
