### PR TITLE
fix: Preserve import order when transforming barrel file imports

### DIFF
--- a/.changeset/clever-wings-work.md
+++ b/.changeset/clever-wings-work.md
@@ -1,0 +1,7 @@
+---
+"swc-plugin-barrel-files": patch
+---
+
+Preserve import order when transforming barrel file imports
+
+This change ensures that when barrel file imports are transformed, the resulting imports maintain the order defined in the barrel file rather than being alphabetically sorted. This provides more predictable and consistent output that respects the original barrel file's export ordering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,18 +222,18 @@ dependencies = [
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -1074,9 +1074,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
@@ -1178,15 +1178,15 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1688,6 +1688,7 @@ dependencies = [
 name = "swc_plugin_barrel_files"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
  "once_cell",
  "path-absolutize",
  "pathdiff",
@@ -1727,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "swc_sourcemap"
-version = "9.3.2"
+version = "9.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9755c673c6a83c461e98fa018f681adb8394a3f44f89a06f27e80fd4fe4fa1e4"
+checksum = "3cd6e0cad02163875258edaf9ae6004e2526be137bdde6a46c540515615949b1"
 dependencies = [
  "base64-simd",
  "bitvec",
@@ -2223,6 +2224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,7 +2244,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2258,10 +2265,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,13 @@ strip = "symbols"
 once_cell = "1.21.3"
 serde = "1"
 serde_json = "1"
-swc_core = { version = "31.1.0", features = ["ecma_plugin_transform", "ecma_parser"] }
+swc_core = { version = "31.1.0", features = [
+    "ecma_plugin_transform",
+    "ecma_parser",
+] }
 pathdiff = "0.2.3"
 path-absolutize = { version = "3.1.1", features = ["use_unix_paths_on_wasm"] }
+indexmap = "2.10.0"
 
 [dev-dependencies]
 testing = "14.0.1"

--- a/src/import_transformer.rs
+++ b/src/import_transformer.rs
@@ -1,8 +1,9 @@
 use crate::config::{Config, InvalidBarrelMode, UnsupportedImportMode};
 use crate::paths::{dirname, path_join, resolve_relative_path};
 use crate::re_export::{analyze_barrel_file, ReExport};
+use indexmap::IndexMap;
 use once_cell::sync::Lazy;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Mutex;
 use swc_core::common::sync::Lrc;
@@ -21,16 +22,6 @@ use swc_core::ecma::parser::{parse_file_as_module, Syntax};
 /// Cache for parsed barrel files to avoid re-parsing the same file
 static BARREL_CACHE: Lazy<Mutex<HashMap<String, Option<Vec<ReExport>>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
-
-/// Finds a re-export by name in the list of re-exports
-fn find_re_export_by_name<'a>(re_exports: &'a [ReExport], name: &str) -> Option<&'a ReExport> {
-    re_exports.iter().find(|e| e.exported_name == name)
-}
-
-/// Finds a default re-export in the list of re-exports
-fn find_default_re_export(re_exports: &[ReExport]) -> Option<&ReExport> {
-    re_exports.iter().find(|e| e.is_default)
-}
 
 /// Resolves the import path from the barrel file directory and re-export source path
 fn resolve_import_path(barrel_file_dir: &str, source_dir: &str, re_export: &ReExport) -> String {
@@ -88,15 +79,6 @@ fn create_named_specifier(
     })
 }
 
-/// Adds an import specifier to the new_imports HashMap
-fn add_import_specifier(
-    new_imports: &mut HashMap<String, Vec<ImportSpecifier>>,
-    import_path: String,
-    specifier: ImportSpecifier,
-) {
-    new_imports.entry(import_path).or_default().push(specifier);
-}
-
 /// Extracts the imported name from a named import specifier
 fn extract_imported_name(named: &ImportNamedSpecifier) -> String {
     named
@@ -127,7 +109,7 @@ pub fn transform_import(
     barrel_file: &str,
     config: &Config,
 ) -> Result<Option<Vec<ImportDecl>>, String> {
-    let mut new_imports = HashMap::new();
+    let mut new_imports: IndexMap<String, Vec<ImportSpecifier>> = IndexMap::new();
     let mut missing_exports = Vec::new();
 
     let barrel_file_dir = dirname(barrel_file);
@@ -135,43 +117,16 @@ pub fn transform_import(
     let re_exports = parse_barrel_file_exports(barrel_file, config)?;
 
     if let Some(re_exports) = re_exports {
+        let mut import_specifiers_map = HashMap::new();
+
         for specifier in &import_decl.specifiers {
             match specifier {
                 ImportSpecifier::Named(named) => {
                     let imported_name = extract_imported_name(named);
-
-                    if let Some(re_export) = find_re_export_by_name(&re_exports, &imported_name) {
-                        let import_path =
-                            resolve_import_path(&barrel_file_dir, source_dir, re_export);
-
-                        let new_specifier = if re_export.is_default {
-                            create_default_specifier(named.span, &named.local)
-                        } else {
-                            create_named_specifier(
-                                named.span,
-                                &named.local,
-                                re_export,
-                                named.is_type_only,
-                            )
-                        };
-
-                        add_import_specifier(&mut new_imports, import_path, new_specifier);
-                    } else {
-                        missing_exports.push(imported_name.clone());
-                    }
+                    import_specifiers_map.insert(imported_name, specifier);
                 }
-                ImportSpecifier::Default(default) => {
-                    // Look for a re-export of the default export
-                    if let Some(re_export) = find_default_re_export(&re_exports) {
-                        let import_path =
-                            resolve_import_path(&barrel_file_dir, source_dir, re_export);
-                        let new_specifier = create_default_specifier(default.span, &default.local);
-
-                        add_import_specifier(&mut new_imports, import_path, new_specifier);
-                    } else {
-                        // The default export was not found in the barrel file
-                        missing_exports.push("default".to_string());
-                    }
+                ImportSpecifier::Default(_) => {
+                    import_specifiers_map.insert("default".to_string(), specifier);
                 }
                 ImportSpecifier::Namespace(_) => match config.unsupported_import_mode {
                     UnsupportedImportMode::Error => {
@@ -181,12 +136,61 @@ pub fn transform_import(
                     }
                     UnsupportedImportMode::Warn => {
                         eprintln!("Warning: Namespace imports are not supported for barrel file optimization. Import from {} will be skipped.", import_decl.src.value);
-                        continue;
                     }
-                    UnsupportedImportMode::Off => {
-                        continue;
-                    }
+                    UnsupportedImportMode::Off => {}
                 },
+            }
+        }
+
+        let mut found_exports = HashSet::new();
+        let mut has_default_export = false;
+
+        // Iterate through re_exports in barrel file order to preserve order
+        for re_export in &re_exports {
+            found_exports.insert(&re_export.exported_name);
+            if re_export.is_default {
+                has_default_export = true;
+            }
+
+            if let Some(specifier) = import_specifiers_map.get(&re_export.exported_name) {
+                let import_path = resolve_import_path(&barrel_file_dir, source_dir, re_export);
+
+                let new_specifier = match specifier {
+                    ImportSpecifier::Named(named) => {
+                        if re_export.is_default {
+                            create_default_specifier(named.span, &named.local)
+                        } else {
+                            create_named_specifier(
+                                named.span,
+                                &named.local,
+                                re_export,
+                                named.is_type_only,
+                            )
+                        }
+                    }
+                    ImportSpecifier::Default(default) => {
+                        create_default_specifier(default.span, &default.local)
+                    }
+                    ImportSpecifier::Namespace(_) => {
+                        continue;
+                    }
+                };
+
+                new_imports
+                    .entry(import_path)
+                    .or_default()
+                    .push(new_specifier);
+            }
+        }
+
+        // Check for any imported specifiers that weren't found in the barrel file
+        for imported_name in import_specifiers_map.keys() {
+            if imported_name == "default" {
+                if !has_default_export {
+                    missing_exports.push("default".to_string());
+                }
+            } else if !found_exports.contains(imported_name) {
+                missing_exports.push(imported_name.clone());
             }
         }
 
@@ -202,11 +206,7 @@ pub fn transform_import(
         // Create new import declarations for each source path
         let mut result = Vec::new();
 
-        // Sort the imports by source path for deterministic output
-        let mut sorted_imports: Vec<_> = new_imports.into_iter().collect();
-        sorted_imports.sort_by(|a, b| a.0.cmp(&b.0));
-
-        for (source_path, specifiers) in sorted_imports {
+        for (source_path, specifiers) in new_imports {
             let new_import = ImportDecl {
                 span: import_decl.span,
                 specifiers,


### PR DESCRIPTION
Preserve import order when transforming barrel file imports

This change ensures that when barrel file imports are transformed, the resulting imports maintain the order defined in the barrel file rather than being alphabetically sorted. This provides more predictable and consistent output that respects the original barrel file's export ordering.

